### PR TITLE
Add functionality to create labels for repos in an organisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+
+config.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 `org-label-manager` is a small tool to add a label to every repo in a GitHub organisation.
 
+### Usage
+
+The tool takes no arguments.
+
+It can be ran from the command line, after using `npm install`, with `node index.js`.
+
+This application relies on a config file like the following. All of the fields are mandatory. The config file must be in the directory that you're currently in.
+
+#### `config.json`
+```json
+{
+  'org': 'org-name',
+  'label': {
+    'name': 'label-name',
+    'color': '89abcd'
+  },
+  'auth': {
+    'user': 'user',
+    'token': '## generate one from https://github.com/settings/tokens ##'
+  }
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This application relies on a config file like the following. All of the fields a
 #### `config.json`
 ```json
 {
-  'org': 'org-name',
-  'label': {
-    'name': 'label-name',
-    'color': '89abcd'
+  "org": "org-name",
+  "label": {
+    "name": "label-name",
+    "color": "89abcd"
   },
-  'auth': {
-    'user': 'user',
-    'token': '## generate one from https://github.com/settings/tokens ##'
+  "auth": {
+    "user": "user",
+    "token": "## generate one from https://github.com/settings/tokens ##"
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -32,8 +32,18 @@ request
       let repoLabelUrl = repo.url + '/labels';
 
       request.post(repoLabelUrl, reqOpts)
-        .then(() => console.log(`Added ${label} to ${repo.name}`));
-      
+        .then(() => console.log(`Added "${label.name}" to "${repo.name}"`))
+        .catch(e => {
+            let error = e.error;
+            let errorPrefix = `Could not add "${label.name}" for "${repo.name}"`;
+            if (error.message === 'Validation Failed' && error.errors.length === 1 && error.errors[0].field === 'name') {
+              console.log(`${errorPrefix} because it already exists.`);
+            } else if (error.message === 'Not Found') {
+              console.log(`${errorPrefix} due to insufficient permissions.`);
+            } else {
+              console.log(`${errorPrefix} due to unexpected error: ${error.message}.`);
+            }
+          }); 
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-let request = require('request-promise-native');
-let fs = require('fs');
+const request = require('request-promise-native');
+const fs = require('fs');
 
-let config = JSON.parse(fs.readFileSync('./config.json', 'utf-8'));
+const config = JSON.parse(fs.readFileSync('./config.json', 'utf-8'));
 
-let org = config.org;
-let label = config.label;
+const org = config.org;
+const label = config.label;
 
-let user = config.auth.user;
-let token = config.auth.token;
+const user = config.auth.user;
+const token = config.auth.token;
 
-let opts = {
+const opts = {
   'headers': {
     'User-Agent': 'ISISBusApps-OrgLabels'
   },

--- a/index.js
+++ b/index.js
@@ -1,0 +1,41 @@
+let request = require('request-promise-native');
+let fs = require('fs');
+
+let config = JSON.parse(fs.readFileSync('./config.json', 'utf-8'));
+
+let org = config.org;
+let label = config.label;
+
+let user = config.auth.user;
+let token = config.auth.token;
+
+let opts = {
+  'headers': {
+    'User-Agent': 'ISISBusApps-OrgLabels'
+  },
+  'auth': {
+    'user': user,
+    'pass': token,
+    'sendImmediately': true
+  },
+  json: true
+};
+
+request
+  .get(`https://api.github.com/orgs/${org}/repos`, opts)
+  .then(repos => {
+    repos.forEach(repo => {
+      console.log(repo.url, label);
+
+      let reqOpts = Object.assign({}, opts, {
+        'json': label
+      });
+      let repoLabelUrl = repo.url + '/labels';
+
+      request.post(repoLabelUrl, reqOpts)
+        .then(() => console.log(`Added ${label} to ${repo.name}`));
+      
+    });
+  });
+
+

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ request
   .get(`https://api.github.com/orgs/${org}/repos`, opts)
   .then(repos => {
     repos.forEach(repo => {
-      console.log(repo.url, label);
 
       let reqOpts = Object.assign({}, opts, {
         'json': label

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "org-label-manager",
+  "version": "0.0.1",
+  "description": "A small tool to add a label every repo in a GitHub organisation.",
+  "main": "index.js",
+  "author": "ISIS Business Applications",
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5"
+  }
+}


### PR DESCRIPTION
Adds a simple tool to create labels for all repositories in an organisation.

See `README.md` for more info.

Closes #1.