### PR TITLE
#4, #5: Add filtering for repositories

### DIFF
--- a/src/update-labels-in-github.js
+++ b/src/update-labels-in-github.js
@@ -168,7 +168,8 @@ async function run() {
     const exclude = toUpdate.exclude;
     const allRepos = await fetchReposForOrg(toUpdate.org);
 
-    const reposToUpdate = filterExcludedRepos(allRepos, exclude);
+    const reposToUpdate = filterExcludedRepos(allRepos, exclude)
+            .filter(r => !r.archived);
 
     reposToUpdate.forEach(r => updateRepo(r));
 


### PR DESCRIPTION
Closes #4, closes #5 

Allows us to specify repositories to be excluded from updating repositories for an organisation.

Skips archived repositories - archived repositories can't have their labels updated.