### PR TITLE
Fix validation output

### DIFF
--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -8,8 +8,8 @@ const validate = ajv.compile(config);
 
 module.exports = function(data) {
   if(!validate(data)) {
-    console.error('Invalid configuration provided.', ajv.errorsText());
-    throw 'Invalid configuration provided.';
+    console.error('Invalid configuration provided: ' + ajv.errorsText(validate.errors));
+    throw new Error('Invalid configuration provided.');
   }
 };
 


### PR DESCRIPTION
The validation output was empty on failure as it needed the list of errors passed in. This also adds the exception to the standard error output as well.